### PR TITLE
Fix heatmap save and update requirements

### DIFF
--- a/dancer/ui.py
+++ b/dancer/ui.py
@@ -751,7 +751,7 @@ Thanks to you for using this software!""") )
 			#	self.OOR(),
 			#	self.amplitude_centering_slider.get()
 			#)
-			self.audioo_canvas.savefig(fileName, bbox_inches="tight", pad_inches=0)
+			self.audioo_canvas.figure.savefig(fileName, bbox_inches="tight", pad_inches=0)
 		else:
 			print("File save cancelled.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy<1.24
-librosa==0.10.0.post2
-matplotlib<3.8
-scipy==1.9.3
+numpy
+librosa
+matplotlib
+scipy
 pyinstaller
 requests


### PR DESCRIPTION
- Fix AttributeError: FigureCanvasTkAgg has no savefig; call savefig on figure instead of canvas
- Remove outdated version pins in requirements.txt that prevented installation with modern Python